### PR TITLE
Fix KeyError in _get_ordered_instructions and UnboundLocalError in metrics tracking

### DIFF
--- a/code_loop_explorer.py
+++ b/code_loop_explorer.py
@@ -348,7 +348,7 @@ Remember to use ```typescript code blocks for your transaction code.
                     'duration': (datetime.now() - message_start_time).total_seconds(),
                     'reward': reward if 'reward' in locals() else 0,
                     'total_reward': env.total_reward,
-                    'instructions_discovered': instructions_discovered
+                    'instructions_discovered': instructions_discovered if 'instructions_discovered' in locals() else {}
                 }
                 
                 self.metrics['messages'].append(message_metrics)

--- a/voyager/surfpool_env.py
+++ b/voyager/surfpool_env.py
@@ -328,12 +328,13 @@ class SurfpoolEnv(gym.Env):
                 'data': base58.b58decode(ix.data),
             })
             # pdb.set_trace()
-            ordered_instructions.extend(
-                [{
-                    'program_id': message.account_keys[inner_instruction.program_id_index],
-                    'data': base58.b58decode(inner_instruction.data),
-                } for inner_instruction in inner_instructions[idx]]
-            )
+            if idx in inner_instructions:
+                ordered_instructions.extend(
+                    [{
+                        'program_id': message.account_keys[inner_instruction.program_id_index],
+                        'data': base58.b58decode(inner_instruction.data),
+                    } for inner_instruction in inner_instructions[idx]]
+                )
         return ordered_instructions
     
     def _calculate_reward(self, tx_result: GetTransactionResp) -> float:


### PR DESCRIPTION
## Summary

  - Fix `KeyError` crash in `_get_ordered_instructions` when a
  top-level instruction has no inner instructions
  - Fix `UnboundLocalError` for `instructions_discovered` when no
  code blocks are found in a response

  ## Problem

  ### KeyError in reward calculation

  `_get_ordered_instructions` assumes every instruction index has
  an entry in `inner_instructions`. When a simple instruction
  (e.g. `SystemProgram.transfer`) has no inner instructions,
  `inner_instructions[idx]` raises `KeyError`, causing the entire
  transaction to be silently discarded as a failure.

  ### UnboundLocalError in metrics

  When the model responds without a `typescript` code block, the
  code falls through to the metrics recording section where
  `instructions_discovered` is referenced but was never
  initialized.

  ## Fix

  **surfpool_env.py** — guard inner instruction lookup with `if
  idx in inner_instructions:`

  **code_loop_explorer.py** — safe fallback:
  `instructions_discovered if 'instructions_discovered' in
  locals() else {}`
